### PR TITLE
Added support for Ubuntu 21.04 LTS and Minecraft 1.17

### DIFF
--- a/ubuntu-hirsute/Dockerfile
+++ b/ubuntu-hirsute/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y \
   supervisor \
   rdiff-backup \
   screen \
-  openjdk-17-jre-headless \
+  openjdk-16-jre-headless \
   rsync \
   git \
   curl \

--- a/ubuntu-hirsute/Dockerfile
+++ b/ubuntu-hirsute/Dockerfile
@@ -1,0 +1,65 @@
+FROM ubuntu:hirsute-20210522
+
+LABEL org.opencontainers.image.authors="William Dizon <wdchromium@gmail.com>, Jez Tucker <jez@tucks.org.uk>"
+LABEL description="Dockerised mineos-node"
+
+# Install the base OS without user interaction
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y \
+  supervisor \
+  rdiff-backup \
+  screen \
+  openjdk-17-jre-headless \
+  rsync \
+  git \
+  curl \
+  rlwrap \
+  build-essential \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Set the local timezone
+RUN ln -snf /usr/share/zoneinfo/$(curl https://ipapi.co/timezone) /etc/localtime
+
+# Install Node.js LTS
+RUN curl -fsSL https://deb.nodesource.com/setup_14.x | bash -
+RUN apt-get install -y nodejs
+
+# Download mineos-node from github
+RUN mkdir -p /usr/games \
+  && cd /usr/games \
+  && git clone https://github.com/hexparrot/mineos-node.git minecraft \
+  && cd minecraft \
+  && git config core.filemode false \
+  && chmod +x service.js mineos_console.js generate-sslcert.sh webui.js \
+  && npm install --unsafe-perm \
+  && ln -s /usr/games/minecraft/mineos_console.js /usr/local/bin/mineos \
+  && cp mineos.conf /etc/mineos.conf 
+
+# Ensure mineos-node node.js server starts up on boot
+# Ubuntu requires privileged containers to use systemd, so we use supervisor instead
+RUN cp /usr/games/minecraft/init/supervisor_conf /etc/supervisor/conf.d/mineos.conf 
+CMD ["/usr/bin/supervisord", "-n", "-c", "/etc/supervisor/supervisord.conf"]
+
+# Generate a self-signed untrusted SSL cert
+RUN cd /usr/games/minecraft \
+  && ./generate-sslcert.sh
+
+# Remove no longer required packages and cache files to shrink the image 
+RUN apt-get remove --purge -y build-essential \
+  && apt-get autoremove -y \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Entrypoint allowing for setting of mc password
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+
+# Expose port 8443 for web management, 25565-25570 for Minecraft servers
+EXPOSE 8443 25565-25570
+VOLUME /var/games/minecraft
+
+# Defaults for startup
+ENV USER_PASSWORD=random_see_log USER_NAME=mc USER_UID=1000 USE_HTTPS=true SERVER_PORT=8443
+
+# EOF
+

--- a/ubuntu-hirsute/Dockerfile
+++ b/ubuntu-hirsute/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y \
   git \
   curl \
   rlwrap \
+  unzip \
   build-essential \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/ubuntu-hirsute/Dockerfile
+++ b/ubuntu-hirsute/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y \
   supervisor \
   rdiff-backup \
   screen \
-  openjdk-16-jre-headless \
+  openjdk-17-jre-headless \
   rsync \
   git \
   curl \

--- a/ubuntu-hirsute/entrypoint.sh
+++ b/ubuntu-hirsute/entrypoint.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -eo pipefail
+
+if [ -z "$USER_PASSWORD" ]; then
+  echo >&2 'You need to specify USER_PASSWORD'
+  exit 1
+fi
+
+if [ "$USER_NAME" ]; then
+  # username specifically provided, will overwrite 'mc'
+  if [[ "$USER_NAME" =~ [^a-zA-Z0-9] ]]; then
+    echo >&2 'USER_NAME must contain only alphanumerics [a-zA-Z0-9]'
+    exit 1
+  fi
+else
+  echo >&2 'USER_NAME not provided; defaulting to "mc"'
+  USER_NAME=mc
+fi
+
+if id -u $USER_NAME >/dev/null 2>&1; then
+  echo "$USER_NAME already exists."
+else
+  useradd -Ms /bin/false $USER_NAME
+  echo "$USER_NAME:$USER_PASSWORD" | chpasswd
+  echo >&2 "Created user: $USER_NAME"
+fi
+  
+if [ ! -f /etc/ssl/certs/mineos.crt ]; then
+  echo >&2 "Generating Self-Signed SSL..."
+  sh /usr/games/minecraft/generate-sslcert.sh
+  update-ca-certificates -f
+fi
+
+exec "$@"


### PR DESCRIPTION
Hello.  I have updated this setup for support as per title, MC 1.17.x, running on latest LTS Ubuntu.  Tested, working ok. 
I also have made an updated mineos docker image which is currently hosted privately.  Perhaps we could also discuss how to get that into mainline.  Happy to write a few docs and readmes to unblock the dark world of docker etc. for newbies.  Let's catch up to see how I can help?

![1 17](https://user-images.githubusercontent.com/1470172/121942040-f1523200-cd47-11eb-8ec4-241f912a069e.png)
